### PR TITLE
Add CompleteAwakeableEntryMessage.failure

### DIFF
--- a/dev/restate/service/protocol.proto
+++ b/dev/restate/service/protocol.proto
@@ -177,7 +177,10 @@ message CompleteAwakeableEntryMessage {
   bytes invocation_id = 3;
   uint32 entry_index = 4;
 
-  bytes payload = 5;
+  oneof result {
+    bytes value = 5;
+    Failure failure = 6;
+  };
 }
 
 // --- Nested messages


### PR DESCRIPTION
Part of https://github.com/restatedev/restate/issues/678, to achieve API symmetry we should allow SDKs to implement an API to fail awakeables.