### PR TITLE
Modify Input/Output schema in deployment_manifest_schema.json

### DIFF
--- a/deployment_manifest_schema.json
+++ b/deployment_manifest_schema.json
@@ -49,22 +49,39 @@
                 "input": {
                   "type": "object",
                   "title": "InputPayload",
-                  "description": "Description of an input payload.",
+                  "description": "Description of an input payload. This will be used by Restate to validate incoming requests.",
                   "properties": {
+                    "required": {
+                      "type": "boolean",
+                      "description": "If true, a body MUST be sent with a content-type, even if the body length is zero."
+                    },
                     "contentType": {
                       "type": "string",
-                      "description": "Content type of the input. This will be used by Restate to validate incoming requests. It can accept wildcards, in the same format as the 'Accept' header."
-                    },
-                    "empty": {
-                      "enum": ["ALLOW", "DISALLOW", "REQUIRE"],
-                      "description": "If ALLOW, Restate will allow requests with empty body without content-type, if DISALLOW, Restate won't allow requests with empty input and no content-type, if REQUIRE, Restate will allow only requests with empty input and no content-type."
+                      "description": "Content type of the input. It can accept wildcards, in the same format as the 'Accept' header. When this field is unset, it implies emptiness, meaning no content-type/body is expected."
                     },
                     "jsonSchema": {}
                   },
                   "additionalProperties": false,
                   "default": {
                     "contentType": "*/*",
-                    "empty": "ALLOW"
+                    "required": false
+                  },
+                  "examples": {
+                    "empty input": {},
+                    "non empty json input": {
+                      "required": true,
+                      "contentType": "application/json",
+                      "jsonSchema": true
+                    },
+                    "either empty or non empty json input": {
+                      "required": false,
+                      "contentType": "application/json",
+                      "jsonSchema": true
+                    },
+                    "bytes input": {
+                      "required": true,
+                      "contentType": "application/octet-stream"
+                    }
                   }
                 },
                 "output": {
@@ -79,25 +96,40 @@
                     "setContentTypeIfEmpty": {
                       "type": "boolean",
                       "description": "If true, the specified content-type is set even if the output is empty."
-                    }
+                    },
+                    "jsonSchema": {}
                   },
                   "additionalProperties": false,
                   "default": {
                     "contentType": "application/json",
                     "setContentTypeIfEmpty": false
+                  },
+                  "examples": {
+                    "empty output": {
+                      "setContentTypeIfEmpty": false
+                    },
+                    "non-empty json output": {
+                      "contentType": "application/json",
+                      "setContentTypeIfEmpty": false,
+                      "jsonSchema": true
+                    },
+                    "protobuf output": {
+                      "contentType": "application/proto",
+                      "setContentTypeIfEmpty": true
+                    }
                   }
                 }
               },
-              "required": [ "name" ],
+              "required": ["name"],
               "additionalProperties": false
             }
           }
         },
-        "required": [ "fullyQualifiedComponentName","componentType", "handlers" ],
+        "required": ["fullyQualifiedComponentName", "componentType", "handlers"],
         "additionalProperties": false
       }
     }
   },
-  "required": [ "minProtocolVersion", "maxProtocolVersion", "components" ],
+  "required": ["minProtocolVersion", "maxProtocolVersion", "components"],
   "additionalProperties": false
 }


### PR DESCRIPTION
This change removes a bit the complexity caused by emptiness, and aligns more with how OpenAPI describes input payloads.

Also: 
* format the document
* add back the output schema (this was mistakenly removed before)