### PR TITLE
Introduce service.Version and discovery.Version enums

### DIFF
--- a/dev/restate/service/discovery.proto
+++ b/dev/restate/service/discovery.proto
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 - Restate Software, Inc., Restate GmbH
+//
+// This file is part of the Restate service protocol, which is
+// released under the MIT license.
+//
+// You can find a copy of the license in file LICENSE in the root
+// directory of this repository or package, or at
+// https://github.com/restatedev/service-protocol/blob/main/LICENSE
+
+syntax = "proto3";
+
+package dev.restate.service.discovery;
+
+option java_package = "dev.restate.generated.service.discovery";
+option go_package = "restate.dev/sdk-go/pb/service/discovery";
+
+// Service discovery protocol version.
+enum ServiceDiscoveryProtocolVersion {
+  SERVICE_DISCOVERY_PROTOCOL_VERSION_UNSPECIFIED = 0;
+  // initial service discovery protocol version using endpoint_manifest_schema.json
+  V1 = 1;
+}

--- a/dev/restate/service/protocol.proto
+++ b/dev/restate/service/protocol.proto
@@ -14,6 +14,13 @@ package dev.restate.service.protocol;
 option java_package = "dev.restate.generated.service.protocol";
 option go_package = "restate.dev/sdk-go/pb/service/protocol";
 
+// Service protocol version.
+enum ServiceProtocolVersion {
+  SERVICE_PROTOCOL_VERSION_UNSPECIFIED = 0;
+  // initial service protocol version
+  V1 = 1;
+}
+
 // --- Core frames ---
 
 // Type: 0x0000 + 0

--- a/endpoint_manifest_schema.json
+++ b/endpoint_manifest_schema.json
@@ -11,12 +11,14 @@
     },
     "minProtocolVersion": {
       "type": "integer",
-      "minimum": 0,
+      "minimum": 1,
+      "maximum": 2147483647,
       "description": "Minimum supported protocol version"
     },
     "maxProtocolVersion": {
       "type": "integer",
-      "maximum": 0,
+      "minimum": 1,
+      "maximum": 2147483647,
       "description": "Maximum supported protocol version"
     },
     "services": {

--- a/service-invocation-protocol.md
+++ b/service-invocation-protocol.md
@@ -160,12 +160,15 @@ replying back with a `404` status code.
 
 #### Content type and protocol version
 
-The request contains the content-type `application/vnd.restate.invocation.vX` where `vX` is the protocol version chosen
-by the runtime, e.g.:
+The request contains the content-type `application/vnd.restate.invocation.vX` where `X` is the service protocol version
+chosen by the runtime, e.g.:
 
 ```http request
 content-type: application/vnd.restate.invocation.v1
 ```
+
+The service protocol version is defined by `ServiceProtocolVersion` in
+[`protocol.proto`](dev/restate/service/protocol.proto).
 
 The SDK MUST return back the same content-type in the successful response case. If the SDK doesn't support the
 content-type, It SHOULD close the stream replying back with a `415` status code.
@@ -425,6 +428,9 @@ When replying, the content-type MUST contain the chosen endpoint manifest type/v
 ```http
 content-type: application/vnd.restate.endpointmanifest.v1+json
 ```
+
+The service discovery protocol version is defined by `ServiceDiscoveryProtocolVersion` in
+[`discovery.proto`](dev/restate/service/discovery.proto).
 
 ## Optional features
 


### PR DESCRIPTION
This commit introduces the service.Version and discovery.Version
enums which define the protocol versions of the service and the
service discovery protocol.

This fixes https://github.com/restatedev/service-protocol/issues/92.

This PR is based on #90.